### PR TITLE
Security: Update deepdiff to fix CVE-2025-58367 (DVOPS-1735)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ PyYAML = ">5.0"
 rich = ">13.0.0"
 wrapt = "^1.15.0"
 jinja2 = "^3.1.2"
+deepdiff = "^8.7.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.0"


### PR DESCRIPTION
## Summary
- Pins deepdiff to ^8.7.0 to fix CVE-2025-58367
- Addresses security vulnerability affecting deepdiff versions >= 5.0.0 and <= 8.6.0

## Test plan
- [ ] Verify dependency update successful
- [ ] Run existing test suite to ensure compatibility
- [ ] Confirm no breaking changes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `deepdiff` runtime dependency pinned to `^8.7.0` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f50062e5b4e942d80200e36fd3b0a0c9328c3869. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->